### PR TITLE
No need to split opendkim.conf.SigningTable

### DIFF
--- a/opendkim/key.sls
+++ b/opendkim/key.sls
@@ -58,8 +58,7 @@
 
 {% if 'manageSigningTable' in opendkim and 'SigningTable' in opendkim.conf and opendkim.manageSigningTable == true %}
 
-{%- set type, filePath = opendkim.conf.SigningTable.split(':') %}
-{{ filePath }}:
+{{ opendkim.conf.KeyTable }}:
   file.managed:
     - mode: 640
     - source: salt://opendkim/files/SigningTable.tmpl

--- a/opendkim/key.sls
+++ b/opendkim/key.sls
@@ -58,7 +58,7 @@
 
 {% if 'manageSigningTable' in opendkim and 'SigningTable' in opendkim.conf and opendkim.manageSigningTable == true %}
 
-{{ opendkim.conf.KeyTable }}:
+{{ opendkim.conf.SigningTable }}:
   file.managed:
     - mode: 640
     - source: salt://opendkim/files/SigningTable.tmpl


### PR DESCRIPTION
Since there is no ":" in pillar.example for this entry, there is no need to split it.
If there is a use case, please add to pillar.example.
Was not working on my side before, but is now.